### PR TITLE
Fixed TextEdit focus issue

### DIFF
--- a/lib/QMBForm/src/main/java/com/quemb/qmbform/FormManager.java
+++ b/lib/QMBForm/src/main/java/com/quemb/qmbform/FormManager.java
@@ -10,6 +10,8 @@ import com.quemb.qmbform.descriptor.RowDescriptor;
 import com.quemb.qmbform.descriptor.SectionDescriptor;
 import com.quemb.qmbform.descriptor.Value;
 import com.quemb.qmbform.view.Cell;
+import com.quemb.qmbform.view.FormEditTextFieldCell;
+import com.quemb.qmbform.view.FormEditTextViewFieldCell;
 
 import android.app.Activity;
 import android.content.Context;
@@ -42,7 +44,7 @@ public class FormManager implements OnFormRowChangeListener, OnFormRowValueChang
     }
 
 
-    public void setup(FormDescriptor formDescriptor, final ListView listView, Activity activity){
+    public void setup(final FormDescriptor formDescriptor, final ListView listView, Activity activity){
 
         Context context = activity;
 
@@ -53,7 +55,7 @@ public class FormManager implements OnFormRowChangeListener, OnFormRowValueChang
 
         final FormAdapter adapter = FormAdapter.newInstance(mFormDescriptor, context);
         listView.setAdapter(adapter);
-        listView.setDescendantFocusability(ViewGroup.FOCUS_AFTER_DESCENDANTS);
+        //listView.setDescendantFocusability(ViewGroup.FOCUS_AFTER_DESCENDANTS);
         listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {

--- a/lib/QMBForm/src/main/java/com/quemb/qmbform/adapter/FormAdapter.java
+++ b/lib/QMBForm/src/main/java/com/quemb/qmbform/adapter/FormAdapter.java
@@ -6,6 +6,7 @@ import com.quemb.qmbform.descriptor.RowDescriptor;
 import com.quemb.qmbform.descriptor.SectionDescriptor;
 import com.quemb.qmbform.CellViewFactory;
 import com.quemb.qmbform.view.Cell;
+import com.quemb.qmbform.view.FormEditTextFieldCell;
 
 import android.content.Context;
 import android.view.View;
@@ -23,17 +24,19 @@ public class FormAdapter extends BaseAdapter {
     private ArrayList<FormItemDescriptor> mItems;
     private Context mContext;
     private Boolean mEnableSectionSeperator;
+    private int focusedEditTextRow = -1;
 
     public static FormAdapter newInstance(FormDescriptor formDescriptor, Context context){
         FormAdapter formAdapter = new FormAdapter();
         formAdapter.mFormDescriptor = formDescriptor;
         formAdapter.mContext = context;
         formAdapter.setEnableSectionSeperator(true);
+        formAdapter.setup();
+
         return formAdapter;
     }
 
-    @Override
-    public int getCount() {
+    public void setup() {
         mItems = new ArrayList<FormItemDescriptor>();
         int sectionCount = 1;
         for (SectionDescriptor sectionDescriptor : mFormDescriptor.getSections()){
@@ -49,7 +52,10 @@ public class FormAdapter extends BaseAdapter {
             }
             sectionCount++;
         }
-
+    }
+    
+    @Override
+    public int getCount() {
         return mItems.size();
     }
 
@@ -66,9 +72,25 @@ public class FormAdapter extends BaseAdapter {
 
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
+        Cell cell = CellViewFactory.getInstance().createViewForFormItemDescriptor(mContext,getItem(position));
+        if (cell instanceof FormEditTextFieldCell) {
+            processEditTextCell((FormEditTextFieldCell)cell, position);
+        }
+        return cell;
+    }
 
-
-        return CellViewFactory.getInstance().createViewForFormItemDescriptor(mContext,getItem(position));
+    private void processEditTextCell(FormEditTextFieldCell cell, final int row) {
+        if (row == focusedEditTextRow) {
+            cell.getEditView().requestFocus();
+        }
+        cell.getEditView().setOnFocusChangeListener(new View.OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
+                if (hasFocus) {
+                    focusedEditTextRow = row;
+                }
+            }
+        });
     }
 
 

--- a/lib/QMBForm/src/main/java/com/quemb/qmbform/view/FormEditTextFieldCell.java
+++ b/lib/QMBForm/src/main/java/com/quemb/qmbform/view/FormEditTextFieldCell.java
@@ -98,4 +98,8 @@ public class FormEditTextFieldCell extends FormTitleFieldCell {
         return mEditView;
     }
 
+    public void focusEditText() {
+        mEditView.requestFocus();
+    }
+
 }


### PR DESCRIPTION
There was a problem that textedit receives focus and immediately loses it, but text cursor still blinked in the textedit and keyboard stays on the screen. I found that fix in other fork and luckily it helped — now focus stays in the field. Probably, it's workaround and not fix, but I haven't find any proper way. [This SO thread](http://stackoverflow.com/a/12730726/2105993) tells more about android's *peculiarity*. 