### PR TITLE
Compilation errors with the previous PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ android:
     # - tools
 
     # The BuildTools version used by your project
-    - build-tools-21.1.2
+    - build-tools-23.0.3
 
     # The SDK version used to compile your project
     - android-23
 
     # Specify at least one system image,
     # if you need to run emulator(s) during your tests
-    - sys-img-armeabi-v7a-android-21
+    - sys-img-armeabi-v7a-android-23
 
 before_install:
     - chmod +x gradlew

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,13 @@ android:
     # - tools
 
     # The BuildTools version used by your project
-    - build-tools-23.0.3
+    - build-tools-23.0.2
 
     # The SDK version used to compile your project
     - android-23
+
+    # Design Support Library
+    - extra-android-m2repository
 
     # Specify at least one system image,
     # if you need to run emulator(s) during your tests
@@ -20,4 +23,5 @@ before_install:
     - chmod +x gradlew
 
 script:
-    - TERM=dumb ./gradlew -i test
+    # - TERM=dumb ./gradlew -i test
+    - ./gradlew build connectedCheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ android:
     - build-tools-21.1.2
 
     # The SDK version used to compile your project
-    - android-21
+    - android-23
 
     # Specify at least one system image,
     # if you need to run emulator(s) during your tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ android:
   components:
     # Uncomment the lines below if you want to
     # use the latest revision of Android SDK Tools
-    # - platform-tools
-    # - tools
+    - platform-tools
+    - tools
 
     # The BuildTools version used by your project
     - build-tools-23.0.2

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.3'
+    buildToolsVersion '23.0.2'
 
     defaultConfig {
         applicationId "com.quemb.qmbform.sample"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    lintOptions {
+        abortOnError false
+    }
 }
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,5 +31,5 @@ android {
 }
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(":lib:QMBForm")
+    compile project(':lib:QMBForm')
 }

--- a/app/src/main/java/com/quemb/qmbform/sample/controller/SampleActivity.java
+++ b/app/src/main/java/com/quemb/qmbform/sample/controller/SampleActivity.java
@@ -4,17 +4,14 @@ import com.quemb.qmbform.sample.R;
 import com.quemb.qmbform.sample.model.TabItem;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentActivity;
 import android.support.v4.view.ViewPager;
-import android.support.v7.app.ActionBarActivity;
-import android.view.WindowManager;
+import android.support.v7.app.AppCompatActivity;
 
 import java.util.ArrayList;
 import java.util.List;
 
 
-public class SampleActivity extends ActionBarActivity {
+public class SampleActivity extends AppCompatActivity {
 
     public static String TAG = "SampleActivity";
 

--- a/app/src/main/java/com/quemb/qmbform/sample/controller/SampleMultivalueSectionFormFragment.java
+++ b/app/src/main/java/com/quemb/qmbform/sample/controller/SampleMultivalueSectionFormFragment.java
@@ -74,6 +74,9 @@ public class SampleMultivalueSectionFormFragment extends Fragment implements OnF
 
         mChangesMap = new HashMap<String, Value<?>>();
 
+        // More styles and colors for cells
+        HashMap<String, Object> cellConfig = new HashMap<>(8);
+
         // TextAppearance for section, label, value and button
         //cellConfig.put(CellDescriptor.APPEARANCE_SECTION, Integer.valueOf(R.style.TextAppearance_Form_Section));
         //cellConfig.put(CellDescriptor.APPEARANCE_TEXT_LABEL, Integer.valueOf(R.style.TextAppearance_Form_Label));

--- a/build.gradle
+++ b/build.gradle
@@ -16,4 +16,9 @@ allprojects {
     repositories {
         mavenCentral()
     }
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:unchecked"
+        }
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip

--- a/lib/QMBForm/build.gradle
+++ b/lib/QMBForm/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "23.0.2"
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 21

--- a/lib/QMBForm/build.gradle
+++ b/lib/QMBForm/build.gradle
@@ -8,6 +8,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.2"
+
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 21
@@ -26,6 +27,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+    lintOptions {
+        abortOnError false
     }
     sourceSets {
         androidTest {

--- a/lib/QMBForm/src/main/java/com/quemb/qmbform/view/FormDetailTextInlineFieldCell.java
+++ b/lib/QMBForm/src/main/java/com/quemb/qmbform/view/FormDetailTextInlineFieldCell.java
@@ -1,10 +1,14 @@
 package com.quemb.qmbform.view;
 
 import com.quemb.qmbform.R;
+import com.quemb.qmbform.descriptor.CellDescriptor;
 import com.quemb.qmbform.descriptor.RowDescriptor;
 import com.quemb.qmbform.descriptor.Value;
 
 import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.DisplayMetrics;
+import android.util.TypedValue;
 import android.widget.TextView;
 
 /**


### PR DESCRIPTION
Hi, these are corrections to the compilation errors the my previous PR.

The changes are made around the android theme. If nothing is specified (example is the first tab in sample app), the form adopts the current theme. Note that 2 themes are included, just change the app theme in Manifest to see.

In the 3rd tab of sample app, specific text appearances and colors are applied to the form. So to change the form UI, just add themes and color attributes to the app theme (if not standard, compared to the normal app theme), then apply them when building the form.

Hope this helps
Philippe